### PR TITLE
Remove duplicated link for CodeClimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ Voici le lien pour créer un [thème enfant](https://wpformation.com/theme-enfan
 - [Code Climate](https://codeclimate.com/)
 - [PHP Parser](https://github.com/nikic/PHP-Parser)
 - [Scrutinizer](https://scrutinizer-ci.com/)
-- [codeclimate](https://codeclimate.com/)
 
 ###  Qualité du code
 


### PR DESCRIPTION
I just remove the duplicated link for CodeClimate in the P5 section as I don't think it was intended.